### PR TITLE
perf preallocation of btTriangleMesh

### DIFF
--- a/src/BulletCollision/CollisionShapes/btTriangleMesh.cpp
+++ b/src/BulletCollision/CollisionShapes/btTriangleMesh.cpp
@@ -150,7 +150,7 @@ void btTriangleMesh::preallocateVertices(int numverts)
 	}
 	else
 	{
-		m_3componentVertices.reserve(numverts);
+		m_3componentVertices.reserve(3 * numverts);
 	}
 }
 


### PR DESCRIPTION
for m_3componentVertices, its size should be 3 times of numverts